### PR TITLE
Fix brace-expansion security advisory

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/package-lock.json
+++ b/package-lock.json
@@ -184,12 +184,6 @@
             "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
             "license": "MIT"
         },
-        "node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "license": "MIT"
-        },
         "node_modules/body-parser": {
             "version": "1.20.6",
             "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
@@ -212,16 +206,6 @@
             "engines": {
                 "node": ">= 0.8",
                 "npm": "1.2.8000 || >= 1.4.16"
-            }
-        },
-        "node_modules/brace-expansion": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
             }
         },
         "node_modules/buffer-from": {
@@ -1128,6 +1112,22 @@
             },
             "engines": {
                 "node": "*"
+            }
+        },
+        "node_modules/minimatch/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "license": "MIT"
+        },
+        "node_modules/minimatch/node_modules/brace-expansion": {
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
             }
         },
         "node_modules/minimist": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "jshint": "^2.13.6"
     },
     "overrides": {
+        "brace-expansion": "1.1.18",
         "lodash": "^4.18.1",
         "minimatch": "^3.1.5"
     }


### PR DESCRIPTION
## What changed

- Override `brace-expansion` to the patched `1.1.18` backport.
- Regenerate `package-lock.json`.
- Add the repository's seven-day npm release quarantine.

## Why

Dependabot reported GHSA-mh99-v99m-4gvg through the legacy `jshint -> cli -> glob -> minimatch -> brace-expansion` dependency chain. The initial 5.0.8 fix is covered by follow-up advisory GHSA-rgw5-rvv9-x895, while 5.0.9 requires Node 20+. Version 1.1.18 fixes both advisories while preserving this project's declared Node 18 support and satisfying minimatch's existing 1.x dependency range.

## Impact

The transitive denial-of-service vulnerability is removed without changing application behavior or dropping Node 18 compatibility.

## Validation

- `npm ci --ignore-scripts`
- `npm audit --package-lock-only --ignore-scripts` - 0 vulnerabilities
- `npm ls brace-expansion minimatch glob --all`
- Brace expansion runtime smoke test
- `node --check` across repository JavaScript files
- `git diff --check`
