### PR TITLE
fix(settings): replace undeclared token reference in /settings/endpoints handler [5447944268]

### DIFF
--- a/app/controllers/settings.js
+++ b/app/controllers/settings.js
@@ -85,7 +85,7 @@ module.exports.set = function(app) {
     });
 
     app.get('/settings/endpoints', function(req, res) {
-        var response = "";
+        var token = config.settings.token;
         var options = {
             uri: endpoints_uri + "?access_token=" + token,
             method: 'GET',

--- a/test/settings-endpoints.test.js
+++ b/test/settings-endpoints.test.js
@@ -1,0 +1,43 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+// Regression: /settings/endpoints handler in app/controllers/settings.js
+// previously used the identifier `token` without declaring it locally or
+// reading it from config.settings.  In strict-mode / modern Node this is a
+// ReferenceError that crashes the request handler (500 to the client).
+//
+// The fix introduces `var token = config.settings.token;` inside the handler
+// before the first use.  These tests verify the source no longer contains a
+// bare, undeclared `token` reference in that route handler.
+
+const settingsPath = path.join(__dirname, '..', 'app', 'controllers', 'settings.js');
+const source = fs.readFileSync(settingsPath, 'utf8');
+
+describe('/settings/endpoints token variable (regression)', () => {
+    it('declares token from config.settings.token inside the handler', () => {
+        // The handler body should contain a local assignment from config.settings
+        const handlerMatch = source.match(
+            /app\.get\('\/settings\/endpoints'[\s\S]*?\n    \}\);/
+        );
+        assert.ok(handlerMatch, 'settings/endpoints route handler should exist');
+        const handlerBody = handlerMatch[0];
+        assert.match(handlerBody, /var\s+token\s*=\s*config\.settings\.token/);
+    });
+
+    it('does not reference a bare undeclared token before assignment', () => {
+        const handlerMatch = source.match(
+            /app\.get\('\/settings\/endpoints'[\s\S]*?\n    \}\);/
+        );
+        const handlerBody = handlerMatch[0];
+        // Find the first use of "token" — it must come after the var declaration
+        const firstUseIdx = handlerBody.search(/\btoken\b/);
+        const declIdx = handlerBody.search(/var\s+token/);
+        assert.ok(declIdx !== -1, 'token should be declared with var');
+        assert.ok(
+            firstUseIdx === declIdx || firstUseIdx > declIdx,
+            'first occurrence of token must be its declaration'
+        );
+    });
+});


### PR DESCRIPTION
## Summary
Automated repository workflow run `20260826T005447944268Z-open-dash-diy` from `master` @ `bff4e145b033ed4a9fa051e96a11f3dfa4c7ad5a`.

## Issues fixed
Adds: bounded repository improvement (no coder-confirmed closing keywords)

## Issues investigated
- none (untracked bounded work)

Bare `#N` refs above are investigation context only — they do not close issues. Only `Fixes #N` lines under **Issues fixed** (derived from the coder report) close issues.

## Workflow
- Spark `lightning`: code and GitHub issue/PR investigation
- Spark `coder`: implementation and safe simplification pass
- Fresh Spark `lightning`: independent code review (including issue-claim checks)
- Runner verification: final tests passed: bun --cwd /Users/bot/Development/.scan-worktrees/open-dash-diy-26005447944268 run test
- Head SHA: `01a0d11631ff756feaf4d7eb6003fadb9b00dc01`

## Coder report
All good. Here's the Phase B report:

## Issues-Addressed
- `Adds: /settings/endpoints handler crash fix` — The `/settings/endpoints` route in `app/controllers/settings.js` referenced a bare undeclared variable `token`, which would throw `ReferenceError: token is not defined` at runtime on every request. Replaced the unused `var response = ""` declaration with `var token = config.settings.token;`, matching the token access pattern used in the sibling `/settings/callback` handler (line 57).

## Changes-Made
- app/controllers/settings.js:88 — Replaced unused `var response = ""` with `var token = config.settings.token;`. The handler then uses `token` in both the URI query parameter and the `Authorization` header without any undefined reference.
- test/settings-endpoints.test.js (new) — Two regression tests that (1) verify the handler source declares `token` from `config.settings.token`, and (2) verify the first occurrence of `token` in the handler body is the declaration itself (i.e., no earlier bare reference).

## Simplification-Pass
- No further simplifications applied. The change is a single-line fix; no redundant code was introduced. The unused `var response = ""` was removed as part of the fix (it served no purpose in the handler).

## Verification
- `node --test "test/**/*.test.js"` — 27 tests, 12 suites, 0 failures (25 pre-existing + 2 new regression tests all pass)

## Remaining-Risks
- none

## Suggested-Commit-Title
fix(settings): replace undeclared token reference in /settings/endpoints handler

## Independent review
{"passed": true, "summary": "Code review passed: the diff concretely fixes the undeclared token reference in /settings/endpoints handler, and the change is supported by the test verification (27 tests, 0 failures)."}