### PR TITLE
fix(api): replace deprecated new Buffer calls with Buffer.from [0141563225]

### DIFF
--- a/app/api/styles.js
+++ b/app/api/styles.js
@@ -56,7 +56,7 @@ var getStyle = function(tempid, callback) {
 }
 
 var saveStyle = function(id, body, callback) {
-    var style = new Buffer(body.content).toString("base64");
+    var style = Buffer.from(body.content).toString("base64");
     if (id == "0") {
         styles.styles.global = style;
     } else {

--- a/app/api/templates.js
+++ b/app/api/templates.js
@@ -51,7 +51,7 @@ var getTemplate = function(tempid, callback) {
 }
 
 var saveTemplate = function(id, body, callback) {
-    var template = new Buffer(body.content).toString("base64");
+    var template = Buffer.from(body.content).toString("base64");
     if (templates.templates[id]) {
         templates.templates[id].content = template;
         templates.templates[id].id = body.name;


### PR DESCRIPTION
## Summary
Automated repository workflow run `20260829T220141563225Z-open-dash-diy` from `master` @ `b67bdc63fa9aa5a943179465997d0b242cabce5d`.

## Issues fixed
Adds: bounded repository improvement (no coder-confirmed closing keywords)

## Issues investigated
- none (untracked bounded work)

Bare `#N` refs above are investigation context only — they do not close issues. Only `Fixes #N` lines under **Issues fixed** (derived from the coder report) close issues.

## Workflow
- Spark `lightning`: code and GitHub issue/PR investigation
- Spark `coder`: implementation and safe simplification pass
- Fresh Spark `lightning`: independent code review (including issue-claim checks)
- Runner verification: final tests passed: bun --cwd /Users/bot/Development/.scan-worktrees/open-dash-diy-29220141563225 run test
- Head SHA: `57c88ea9d831feadc9865cdc51074c8b0f226028`

## Coder report
All 27 tests pass with the fix in place. Both deprecated `new Buffer()` calls are eliminated, syntax is valid, and no other occurrences remain. The change is minimal, behavior-preserving, and matches the repo's existing Buffer usage style.

## Issues-Addressed
- `Adds:` replace deprecated `new Buffer(body.content)` constructor calls with `Buffer.from(body.content)` in the two save handlers, eliminating a Node deprecation warning and avoiding the future-obsoletion hard error on modern runtimes while keeping base64 output identical.

## Changes-Made
- `app/api/templates.js:54` — `saveTemplate` now builds the base64 string via `Buffer.from(body.content)` instead of `new Buffer(body.content)`; identical output, no deprecation warning.
- `app/api/styles.js:59` — same replacement in `saveStyle`; these were the only two `new Buffer` usages left in the app code.

## Simplification-Pass
- No further safe simplifications applied; each handler already matches the surrounding style (var declarations, callback patterns), and touching anything more would be unrelated cleanup.
- Deferred: the sibling handlers still use `var`, loose `==` equality, and inline `Buffer.from` base64 decoding — style-level refactors intentionally left out of this pass.

## Verification
- `grep -rn "new Buffer" --include="*.js" . | grep -v node_modules` — zero matches (previously 2).
- `node --check app/api/templates.js && node --check app/api/styles.js` — syntax OK.
- `node -e "...new Buffer('hello') vs Buffer.from('hello') base64..."` — outputs identical (`aGVsbG8=`), confirming behavior preservation.
- `npm test` — `tests 27, pass 27, fail 0, skipped 0` (same 27/27 as baseline, run with the fix applied).

## Remaining-Risks
- none — the changed expressions produce byte-identical results for string input, and the full test suite passes unchanged.

## Suggested-Commit-Title
fix(api): replace deprecated new Buffer calls with Buffer.from

## Independent review
{"passed": true, "summary": "The diff correctly replaces both deprecated new Buffer(} calls with Buffer.from(}, eliminating deprecation warnings while preserving base64 output; all 27 tests pass."}