### PR TITLE
refactor(controllers): extract duplicated data-build loops into helpers [5825017404]

### DIFF
--- a/app/controllers/styles.js
+++ b/app/controllers/styles.js
@@ -5,32 +5,31 @@ const appRoot = require('app-root-path');
 var styles = new SelfReloadJSON(appRoot + '/data/styles.json');
 var config = new SelfReloadJSON(appRoot + '/data/settings.json');
 
+function buildStyleList() {
+    var style = [];
+    style.push({ "name": "global", "css": Buffer.from(styles.styles.global, 'base64').toString() });
+    styles.styles.dashboards.forEach(temp => {
+        style.push({ name: temp.name, css: Buffer.from(temp.css, 'base64').toString() });
+    });
+    return style;
+}
+
 module.exports.set = function(app) {
 
     app.get('/styles', (request, response) => {
-        var style = []
-        style.push({ "name": "global", "css": Buffer.from(styles.styles.global, 'base64').toString() });
-        styles.styles.dashboards.forEach(temp => {
-            style.push({ name: temp.name, css: Buffer.from(temp.css, 'base64').toString() })
-        });
         var css = Buffer.from(styles.styles.global, 'base64').toString();
         response.render('styles', {
             version: config.settings.version,
-            styles: style,
+            styles: buildStyleList(),
             css: css
         });
     });
 
     app.get('/styles/:id', (request, response) => {
-        var style = []
-        style.push({ "name": "global", "css": Buffer.from(styles.styles.global, 'base64').toString() });
-        styles.styles.dashboards.forEach(temp => {
-            style.push({ name: temp.name, css: Buffer.from(temp.css, 'base64').toString() })
-        });
         var css = Buffer.from(styles.styles.global, 'base64').toString();
         response.render('styles', {
             version: config.settings.version,
-            styles: style,
+            styles: buildStyleList(),
             css: css,
             id: request.params.id
         });

--- a/app/controllers/templates.js
+++ b/app/controllers/templates.js
@@ -6,29 +6,30 @@ var config = new SelfReloadJSON(appRoot + '/data/settings.json');
 var templates = new SelfReloadJSON(appRoot + '/data/templates.json');
 var styles = new SelfReloadJSON(appRoot + '/data/styles.json');
 
+function buildTemplateList() {
+    var temps = [];
+    templates.templates.forEach(temp => {
+        temps.push({ id: temp.id, content: Buffer.from(temp.content, 'base64').toString() });
+    });
+    return temps;
+}
+
 module.exports.set = function(app) {
 
     app.get('/templates', (request, response) => {
-        var temps = []
-        templates.templates.forEach(temp => {
-            temps.push({ id: temp.id, content: Buffer.from(temp.content, 'base64').toString() })
-        });
         var css = Buffer.from(styles.styles.global, 'base64').toString();
         response.render('templates', {
             version: config.settings.version,
-            templates: temps,
+            templates: buildTemplateList(),
             css: css
         });
     });
+
     app.get('/templates/:id', (request, response) => {
-        var temps = []
-        templates.templates.forEach(temp => {
-            temps.push({ id: temp.id, content: Buffer.from(temp.content, 'base64').toString() })
-        });
         var css = Buffer.from(styles.styles.global, 'base64').toString();
         response.render('templates', {
             version: config.settings.version,
-            templates: temps,
+            templates: buildTemplateList(),
             css: css,
             id: request.params.id
         });


### PR DESCRIPTION
## Summary
Automated repository workflow run `20260903T145825017404Z-open-dash-diy` from `master` @ `55b0d959fd0de2b65ab4d13a93172548441f8013`.

## Issues fixed
Adds: bounded repository improvement (no coder-confirmed closing keywords)

## Issues investigated
- none (untracked bounded work)

Bare `#N` refs above are investigation context only — they do not close issues. Only `Fixes #N` lines under **Issues fixed** (derived from the coder report) close issues.

## Workflow
- Spark `lightning`: code and GitHub issue/PR investigation
- Spark `coder`: implementation and safe simplification pass
- Fresh Spark `lightning`: independent code review (including issue-claim checks)
- Runner verification: final tests passed: bun --cwd /Users/bot/Development/.scan-worktrees/open-dash-diy run test
- Head SHA: `6e4bbdffb239db5f242bcb7e800e8527b20a4199`

## Coder report
## Issues-Addressed
- `Adds: consolidate` — extracted duplicated inline data-building loops from two route handlers in each of `app/controllers/templates.js` and `app/controllers/styles.js` into module-level helper functions (`buildTemplateList`, `buildStyleList`), removing the exact duplication between the `/` and `/:id` routes in each file.

## Changes-Made
- `app/controllers/templates.js:9-15` — added `buildTemplateList()` module-level function that builds the `[{id, content}]` array by base64-decoding `templates.templates`; both `GET /templates` and `GET /templates/:id` now call it instead of repeating the same `forEach` inline.
- `app/controllers/styles.js:8-15` — added `buildStyleList()` module-level function that builds the `[{name, css}]` array (global style + dashboard styles, base64-decoded); both `GET /styles` and `GET /styles/:id` now call it instead of repeating the same push/forEach inline.
- Behavior is identical: same render view, same template data, same `version`/`css`/`id` fields; the only difference between the two routes in each file remains the optional `id` param passed through.

## Simplification-Pass
- applied safe simplifications: removed the duplicated 3–5 line loop bodies that were copy-pasted across the two sibling routes in each file; each route body is now a single `render()` call plus one `css` decode.
- deferred risky or unrelated suggestions: the same `Buffer.from(...global...)` decode appears in ~15 other controller files, but extracting that into a shared lib helper would touch many files and cross the "≤2 files" scope for this run; recorded as a candidate for a future `consolidate` pass.

## Verification
- `node --check app/controllers/templates.js && node --check app/controllers/styles.js` — Syntax OK (both files parse).
- `npm run test` — 27 tests, 12 suites, 27 pass, 0 fail, 0 skipped; baseline parity maintained (no regression).
- `git diff --stat` — 2 files changed, 22 insertions(+), 22 deletions(-); no other files touched.

## Remaining-Risks
- none — the refactor is behavior-preserving, all existing tests pass unchanged, and the change is confined to two self-contained controller modules with no exported surface beyond `module.exports.set`.

## Suggested-Commit-Title
refactor(controllers): extract duplicated data-build loops into helpers

## Independent review
{"passed": true, "summary": "Consolidation refactor extracts duplicated inline data-building loops into module-level helpers (buildTemplateList, buildStyleList) across two controller files, removing copy-pasted loop bodies while preserving identical render behavior; all 27 tests pass with baseline parity; change confined to 2 self-contained controller modules."}