### PR TITLE
fix(weather): report non-200 responses instead of hanging the request [2051615307]

### DIFF
--- a/app/api/weather.js
+++ b/app/api/weather.js
@@ -30,11 +30,10 @@ module.exports.set = function(app) {
             url: url,
             json: true
         }, function(error, response, body) {
-            if (error) {
-                callback(error)
-            }
-            if (!error && response.statusCode === 200) {
+            if (!error && response && response.statusCode === 200) {
                 callback(null, body);
+            } else {
+                callback(error || new Error('weather request failed with status ' + (response && response.statusCode)));
             }
         });
     };

--- a/test/weather-endpoints.test.js
+++ b/test/weather-endpoints.test.js
@@ -1,0 +1,87 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+// Regression: /api/weather in app/api/weather.js previously only invoked its
+// httpRequest callback on the success path:
+//
+//     if (error) { callback(error) }
+//     if (!error && response.statusCode === 200) { callback(null, body); }
+//
+// For any non-200 HTTP response (e.g. 401/404 from the upstream SmartThings
+// gateway) both branches were skipped, so getWeather's outer callback was
+// never called and the Express handler never sent a response. The request
+// therefore hung indefinitely and the browser's $.ajax (public/js/weather.js)
+// reported no error, leaving the weather presenters stale.
+//
+// The fix collapses the two branches into a single if/else that reports the
+// error on every non-success outcome, mirroring app/api/updates.js.
+
+const weatherPath = path.join(__dirname, '..', 'app', 'api', 'weather.js');
+const source = fs.readFileSync(weatherPath, 'utf8');
+
+// Pull the body of the innermost httpRequest callback
+// ("function(error, response, body) { ... }") via brace matching,
+// so the assertions don't depend on exact indentation.
+function extractHttpRequestCallbackBody(src) {
+    const start = src.indexOf('function(error, response, body)');
+    assert.ok(start !== -1, 'httpRequest callback should exist in getWeather');
+    let i = src.indexOf('{', start);
+    assert.ok(i !== -1, 'callback body should open with {');
+    let depth = 0;
+    for (; i < src.length; i++) {
+        const ch = src[i];
+        if (ch === '{') depth++;
+        else if (ch === '}') {
+            depth--;
+            if (depth === 0) {
+                return src.slice(src.indexOf('{', start) + 1, i);
+            }
+        }
+    }
+    throw new Error('unbalanced braces in httpRequest callback');
+}
+
+const cbBody = extractHttpRequestCallbackBody(source);
+
+describe('/api/weather getWeather callback (regression)', () => {
+    it('has exactly one success-path callback(null, body) call', () => {
+        const successCalls = cbBody.match(/callback\(null,\s*body\)/g) || [];
+        assert.equal(
+            successCalls.length,
+            1,
+            'exactly one success-path callback(null, body) call should exist'
+        );
+    });
+
+    it('routes non-success outcomes through an error branch', () => {
+        assert.match(
+            cbBody,
+            /\}\s*else\s*\{\s*callback\((error|new Error\()/,
+            'a non-success outcome must call the outer callback with an error'
+        );
+    });
+
+    it('guards response before reading statusCode', () => {
+        assert.match(
+            cbBody,
+            /!\s*error\s*&&\s*response\s*&&\s*response\.statusCode\s*===?\s*200/,
+            'success check must guard response before reading statusCode'
+        );
+    });
+
+    it('does not leave a bare "if (error)" guard that can skip the success check', () => {
+        // The old shape was:
+        //     if (error) { callback(error) }
+        //     if (!error && response.statusCode === 200) { callback(null, body); }
+        // where a non-200 response fell through both branches. The fixed
+        // shape uses a single if/else, so the standalone "if (error)" guard
+        // must be gone.
+        assert.doesNotMatch(
+            cbBody,
+            /if\s*\(\s*error\s*\)\s*\{\s*callback\(\s*error\s*\)/,
+            'the standalone "if (error) { callback(error) }" guard should be removed'
+        );
+    });
+});


### PR DESCRIPTION
## Summary
Automated repository workflow run `20260904T212051615307Z-open-dash-diy` from `master` @ `abbec7ae1382277ab156d212bff8d5fba6e14dcd`.

## Issues fixed
Adds: bounded repository improvement (no coder-confirmed closing keywords)

## Issues investigated
- none (untracked bounded work)

Bare `#N` refs above are investigation context only — they do not close issues. Only `Fixes #N` lines under **Issues fixed** (derived from the coder report) close issues.

## Workflow
- Spark `lightning`: code and GitHub issue/PR investigation
- Spark `coder`: implementation and safe simplification pass
- Fresh Spark `lightning`: independent code review (including issue-claim checks)
- Runner verification: final tests passed: bun --cwd /Users/bot/Development/.scan-worktrees/open-dash-diy run test
- Head SHA: `d9387e2a34d03e5a21f39ad250ae01f63cbe933a`

## Coder report
Everything is in place. Final state: 2 files changed (1 fix + 1 new test), 31/31 tests pass, regression test verified to fail on unfixed code.

## Issues-Addressed
- `Adds: review-fix` — Fixed a hung-request defect in the `/api/weather` handler: non-200 upstream responses (e.g. 401/404 from SmartThings) skipped both callback branches, so the Express handler never responded and the browser `$.ajax` reported no error. No open GitHub issue; this is the `kind: review-fix` candidate from Phase A.

## Changes-Made
- `app/api/weather.js:33-37` — Collapsed the two independent `if` branches in the `httpRequest` callback into a single `if (!error && response && response.statusCode === 200) { callback(null, body); } else { callback(error || new Error('weather request failed with status ' + ...)); }`. This guarantees the outer `getWeather` callback fires on every outcome, so the handler's `res.send` (or error path) always runs. Also guards `response` before reading `statusCode` to avoid a `TypeError` when fetch returns only an error payload. Mirrors the existing `if/else` pattern in `app/api/updates.js`.
- `test/weather-endpoints.test.js` (new) — 4 regression tests that brace-match the `httpRequest` callback body in `app/api/weather.js` and assert: (1) exactly one success-path `callback(null, body)` call, (2) a non-success `else` branch forwarding an error, (3) the success check guards `response` before `response.statusCode`, (4) the old standalone `if (error) { callback(error) }` guard is gone.

## Simplification-Pass
- Applied: removed the redundant `if (error) { callback(error) }` block (its purpose is subsumed by the new `else` branch, which forwards `error` when present and synthesizes a status-bearing `Error` otherwise).
- Deferred: none. The change is 2 files, no refactors beyond the targeted callback.

## Verification
- `npm test` (canonical, from `package.json`: `node --test test/*.test.js`) — **31 pass / 0 fail** (baseline was 27; +4 new, +0 removed). All pre-existing tests still pass.
- `npm test` after `git stash`-ing the fix — **3 of the new tests fail**, confirming the regression test is sensitive to the unfixed shape (28 pass / 3 fail). Fix restored via `git stash pop`.
- `npx jshint app/api/weather.js test/weather-endpoints.test.js` — reports only the pre-existing ES5-vs-ES6 and missing-semicolon complaints that the rest of the repo's tests already carry (no jshint config is committed; the project's canonical check is `npm test`). No new jshint issues introduced by the diff itself beyond what the sibling test files already produce.

## Remaining-Risks
- None. The behavior change is confined to the `getWeather` callback: the success path is byte-identical (`callback(null, body)` on 200), and every non-200 / fetch-error path now resolves the Promise with an error where it previously hung. The upstream SmartThings endpoint's error contract (which it actually returns for auth failures) is out of scope; the fix only guarantees the HTTP response is sent.

## Suggested-Commit-Title
fix(weather): report non-200 responses instead of hanging the request

## Independent review
{"passed": true, "summary": "The diff correctly collapses the two independent if branches into if/else, guarantees the callback fires on all outcomes, adds a response null guard, and mirrors the pattern in app/api/updates.js \u2014 all acceptance criteria and issue claims are supported."}